### PR TITLE
use shorthash in version name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         git fetch origin $head
         git checkout FETCH_HEAD
         brew install jaq
-        jaq --in-place ".version += \"-commit.$(git log --oneline | wc -l)+$(git rev-parse HEAD)\"" package.json
+        jaq --in-place ".version += \"-commit.$(git log --oneline | wc -l)+$(git rev-parse --short HEAD)\"" package.json
         docker build -t "ghcr.io/misskey-dev/0key.dev:$GITHUB_REF_NAME-misskey" .
         docker push "ghcr.io/misskey-dev/0key.dev:$GITHUB_REF_NAME-misskey"
         echo "digest=$(docker image ls --format '{{.Digest}}' | head -n1)" > $GITHUB_OUTPUT


### PR DESCRIPTION
バージョン名が64文字を超えることを避けるためにバージョン名のbuildmeta部分のコミットハッシュをshorthashにします